### PR TITLE
Refactor condition check in ProcessInstantEvent method

### DIFF
--- a/Runtime/StateMachine.cs
+++ b/Runtime/StateMachine.cs
@@ -526,9 +526,10 @@ namespace HFSM {
         /// </param>
         internal void ProcessInstantEvent(EventTransitionBase eventTransition) {
             StateObject originStateObject = eventTransition.OriginStateObject;
-            if (originStateObject.IsActive ||
-                (originStateObject.GetType() == typeof(State.Any) && originStateObject.StateMachine.IsActive) &&
-                eventTransition.AllConditionsMet()) {
+
+            if ((originStateObject.IsActive ||
+                 (originStateObject.GetType() == typeof(State.Any) && originStateObject.StateMachine.IsActive))
+                && eventTransition.AllConditionsMet()) {
 
                 ChangeState(eventTransition);
             }


### PR DESCRIPTION
ProcessInstantEvent had incorrect boolean grouping due to &&/|| precedence. The code evaluated as origin.IsActive || (isAny && smIsActive && AllConditionsMet()), so when origin.IsActive was true the transition could fire without checking AllConditionsMet(). Fix groups the origin-eligibility check and requires AllConditionsMet() for all instant transitions.