### PR TITLE
prevent ProcessInstantEvent condition bypass + enable processInstantly events

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/Runtime/EventTransition.cs
+++ b/Runtime/EventTransition.cs
@@ -41,8 +41,9 @@ namespace HFSM {
         /// </summary>
         public void ListenEvent() {
             if (!(OriginStateObject.IsActive ||
-                  (OriginStateObject.GetType() == typeof(State.Any) && OriginStateObject.StateMachine.IsActive)))
+                  (OriginStateObject.GetType() == typeof(State.Any) && OriginStateObject.StateMachine.IsActive))) {
                 return;
+            }
 
             eventListened = true;
 
@@ -156,8 +157,9 @@ namespace HFSM {
         /// <inheritdoc cref="EventTransition.ListenEvent"/>
         public void ListenEvent(T1 arg1, T2 arg2) {
             if (!(OriginStateObject.IsActive ||
-                  (OriginStateObject.GetType() == typeof(State.Any) && OriginStateObject.StateMachine.IsActive)))
+                  (OriginStateObject.GetType() == typeof(State.Any) && OriginStateObject.StateMachine.IsActive))) {
                 return;
+            }
 
             eventListened = true;
             args.Add((arg1, arg2));
@@ -220,8 +222,9 @@ namespace HFSM {
         /// <inheritdoc cref="EventTransition.ListenEvent"/>
         public void ListenEvent(T1 arg1, T2 arg2, T3 arg3) {
             if (!(OriginStateObject.IsActive ||
-                  (OriginStateObject.GetType() == typeof(State.Any) && OriginStateObject.StateMachine.IsActive)))
+                  (OriginStateObject.GetType() == typeof(State.Any) && OriginStateObject.StateMachine.IsActive))) { 
                 return;
+            }
 
             eventListened = true;
             args.Add((arg1, arg2, arg3));

--- a/Runtime/EventTransition.cs
+++ b/Runtime/EventTransition.cs
@@ -40,13 +40,15 @@ namespace HFSM {
         /// "Any" and <see cref="Transition.OriginStateObject"/>'s <see cref="StateMachine"/> is active.
         /// </summary>
         public void ListenEvent() {
+            if (!(OriginStateObject.IsActive ||
+                  (OriginStateObject.GetType() == typeof(State.Any) && OriginStateObject.StateMachine.IsActive)))
+                return;
+
+            eventListened = true;
+
             if (processInstantly) {
                 OriginStateObject.StateMachine.ProcessInstantEvent(this);
-
-            }else if (OriginStateObject.IsActive ||
-               (OriginStateObject.GetType() == typeof(State.Any) && OriginStateObject.StateMachine.IsActive)) {
-
-                eventListened = true;
+                ConsumeEvent(); // prevent re-processing next Update
             }
         }
 
@@ -90,14 +92,16 @@ namespace HFSM {
 
         /// <inheritdoc cref="EventTransition.ListenEvent"/>
         public void ListenEvent(T arg) {
+            if (!(OriginStateObject.IsActive ||
+                  (OriginStateObject.GetType() == typeof(State.Any) && OriginStateObject.StateMachine.IsActive)))
+                return;
+
+            eventListened = true;
+            args.Add(arg);
+
             if (processInstantly) {
                 OriginStateObject.StateMachine.ProcessInstantEvent(this);
-
-            }else if (OriginStateObject.IsActive ||
-               (OriginStateObject.GetType() == typeof(State.Any) && OriginStateObject.StateMachine.IsActive)) {
-
-                eventListened = true;
-                args.Add(arg);
+                ConsumeEvent(); // clears args + resets eventListened
             }
         }
 
@@ -153,14 +157,16 @@ namespace HFSM {
 
         /// <inheritdoc cref="EventTransition.ListenEvent"/>
         public void ListenEvent(T1 arg1, T2 arg2) {
+            if (!(OriginStateObject.IsActive ||
+                  (OriginStateObject.GetType() == typeof(State.Any) && OriginStateObject.StateMachine.IsActive)))
+                return;
+
+            eventListened = true;
+            args.Add((arg1, arg2));
+
             if (processInstantly) {
                 OriginStateObject.StateMachine.ProcessInstantEvent(this);
-
-            }else if (OriginStateObject.IsActive ||
-               (OriginStateObject.GetType() == typeof(State.Any) && OriginStateObject.StateMachine.IsActive)) {
-
-                eventListened = true;
-                this.args.Add((arg1, arg2));
+                ConsumeEvent();
             }
         }
 
@@ -216,15 +222,16 @@ namespace HFSM {
 
         /// <inheritdoc cref="EventTransition.ListenEvent"/>
         public void ListenEvent(T1 arg1, T2 arg2, T3 arg3) {
+            if (!(OriginStateObject.IsActive ||
+                  (OriginStateObject.GetType() == typeof(State.Any) && OriginStateObject.StateMachine.IsActive)))
+                return;
+
+            eventListened = true;
+            args.Add((arg1, arg2, arg3));
+
             if (processInstantly) {
                 OriginStateObject.StateMachine.ProcessInstantEvent(this);
-
-            } else if (OriginStateObject.IsActive ||
-               (OriginStateObject.GetType() == typeof(State.Any) && OriginStateObject.StateMachine.IsActive)) {
-
-                eventListened = true;
-                args.Add( (arg1, arg2, arg3) );
-                
+                ConsumeEvent();
             }
         }
 

--- a/Runtime/EventTransition.cs
+++ b/Runtime/EventTransition.cs
@@ -48,7 +48,6 @@ namespace HFSM {
 
             if (processInstantly) {
                 OriginStateObject.StateMachine.ProcessInstantEvent(this);
-                ConsumeEvent(); // prevent re-processing next Update
             }
         }
 
@@ -101,7 +100,6 @@ namespace HFSM {
 
             if (processInstantly) {
                 OriginStateObject.StateMachine.ProcessInstantEvent(this);
-                ConsumeEvent(); // clears args + resets eventListened
             }
         }
 
@@ -166,7 +164,6 @@ namespace HFSM {
 
             if (processInstantly) {
                 OriginStateObject.StateMachine.ProcessInstantEvent(this);
-                ConsumeEvent();
             }
         }
 
@@ -231,7 +228,6 @@ namespace HFSM {
 
             if (processInstantly) {
                 OriginStateObject.StateMachine.ProcessInstantEvent(this);
-                ConsumeEvent();
             }
         }
 

--- a/Runtime/State.cs
+++ b/Runtime/State.cs
@@ -91,6 +91,8 @@ namespace HFSM {
         /// This function is called the last update cycle before this <see cref="State"/> becomes inactive.
         /// </summary>
         internal sealed override void Exit() {
+            ConsumeTransitionsEvents();
+            
             IsActive = false;
             OnExit();
         }

--- a/Runtime/StateMachine.cs
+++ b/Runtime/StateMachine.cs
@@ -40,8 +40,6 @@ namespace HFSM {
         private bool initialized;
         private State anyState;
         private bool changedState;
-
-        // MINIMAL RE-ENTRANCY GUARD FOR processInstantly=true
         private bool _isUpdating;
         private EventTransitionBase _pendingInstantEvent;
 

--- a/Runtime/StateMachine.cs
+++ b/Runtime/StateMachine.cs
@@ -415,12 +415,13 @@ namespace HFSM {
             if (availableTransition == null) {
                 availableTransition = CurrentStateObject.GetAvailableTransition();
             }
-            
-            ConsumeTransitionsEvents();
 
             if (availableTransition != null) {
                 ChangeState(availableTransition);
                 changedState = true;
+                
+                if (availableTransition is EventTransitionBase ev)
+                    ev.ConsumeEvent();
             }
             //CurrentStateObject.ConsumeTransitionsEvents();
             //previousStateObject.ConsumeTransitionsEvents(); 
@@ -528,6 +529,8 @@ namespace HFSM {
                 && eventTransition.AllConditionsMet()) {
 
                 ChangeState(eventTransition);
+                
+                eventTransition.ConsumeEvent();
             }
         }
 
@@ -601,6 +604,9 @@ namespace HFSM {
         /// The hierarchical execution of <see cref="Exit"/> is performed in a bottom-up fashion.
         /// </summary>
         internal sealed override void Exit() {
+            if (CurrentStateObject != null)
+                ConsumeTransitionsEvents();
+            
             CurrentStateObject.Exit();
             OnExit();
             IsActive = false;

--- a/Runtime/StateMachine.cs
+++ b/Runtime/StateMachine.cs
@@ -415,12 +415,9 @@ namespace HFSM {
             if (availableTransition == null) {
                 availableTransition = CurrentStateObject.GetAvailableTransition();
             }
-
-            foreach (EventTransitionBase anyEventTransition in anyEventTransitions) {
-                anyEventTransition.ConsumeEvent();
-            }
-            ConsumeTransitionsEvents();
             
+            ConsumeTransitionsEvents();
+
             if (availableTransition != null) {
                 ChangeState(availableTransition);
                 changedState = true;
@@ -526,9 +523,9 @@ namespace HFSM {
         /// </param>
         internal void ProcessInstantEvent(EventTransitionBase eventTransition) {
             StateObject originStateObject = eventTransition.OriginStateObject;
-            if (originStateObject.IsActive ||
-                (originStateObject.GetType() == typeof(State.Any) && originStateObject.StateMachine.IsActive) &&
-                eventTransition.AllConditionsMet()) {
+            if ((originStateObject.IsActive ||
+                 (originStateObject.GetType() == typeof(State.Any) && originStateObject.StateMachine.IsActive))
+                && eventTransition.AllConditionsMet()) {
 
                 ChangeState(eventTransition);
             }

--- a/Runtime/StateMachine.cs
+++ b/Runtime/StateMachine.cs
@@ -40,8 +40,6 @@ namespace HFSM {
         private bool initialized;
         private State anyState;
         private bool changedState;
-        private bool _isUpdating;
-        private EventTransitionBase _pendingInstantEvent;
 
         /// <summary>
         /// Class constructor. Creates a <see cref="StateMachine"/> and initializes it. Throws
@@ -524,20 +522,12 @@ namespace HFSM {
         /// The transtion to be performed.
         /// </param>
         internal void ProcessInstantEvent(EventTransitionBase eventTransition) {
-            if (_isUpdating) {
-                if (_pendingInstantEvent == null) {
-                    _pendingInstantEvent = eventTransition;
-                }
-                return;
-            }
-
             StateObject originStateObject = eventTransition.OriginStateObject;
             if ((originStateObject.IsActive ||
                  (originStateObject.GetType() == typeof(State.Any) && originStateObject.StateMachine.IsActive))
                 && eventTransition.AllConditionsMet()) {
 
                 ChangeState(eventTransition);
-                changedState = true;
                 
                 eventTransition.ConsumeEvent();
             }
@@ -550,20 +540,10 @@ namespace HFSM {
         /// </summary>
         public sealed override void Update() {
             CheckInitialization();
-            _isUpdating = true;
-
             changedState = TryChangeState();
             if (!changedState) {
                 OnUpdate();
                 CurrentStateObject.UpdateInternal();
-            }
-
-            _isUpdating = false;
-
-            if (_pendingInstantEvent != null) {
-                var e = _pendingInstantEvent;
-                _pendingInstantEvent = null;
-                ProcessInstantEvent(e);
             }
         }
 
@@ -572,18 +552,8 @@ namespace HFSM {
         /// hiearchical finite state machine pattern.
         /// </summary>
         internal sealed override void UpdateInternal() {
-            _isUpdating = true;
-
             OnUpdate();
             CurrentStateObject.UpdateInternal();
-
-            _isUpdating = false;
-
-            if (_pendingInstantEvent != null) {
-                var e = _pendingInstantEvent;
-                _pendingInstantEvent = null;
-                ProcessInstantEvent(e);
-            }
         }
 
         /// <summary>

--- a/Runtime/StateMachine.cs
+++ b/Runtime/StateMachine.cs
@@ -420,11 +420,10 @@ namespace HFSM {
                 ChangeState(availableTransition);
                 changedState = true;
                 
-                if (availableTransition is EventTransitionBase ev)
-                    ev.ConsumeEvent();
+                if (availableTransition is EventTransitionBase eventTransition) {
+                    eventTransition.ConsumeEvent();
+                }
             }
-            //CurrentStateObject.ConsumeTransitionsEvents();
-            //previousStateObject.ConsumeTransitionsEvents(); 
 
             return changedState;
         }
@@ -604,9 +603,10 @@ namespace HFSM {
         /// The hierarchical execution of <see cref="Exit"/> is performed in a bottom-up fashion.
         /// </summary>
         internal sealed override void Exit() {
-            if (CurrentStateObject != null)
+            if (CurrentStateObject != null) {
                 ConsumeTransitionsEvents();
-            
+            }
+
             CurrentStateObject.Exit();
             OnExit();
             IsActive = false;

--- a/Runtime/StateMachine.cs
+++ b/Runtime/StateMachine.cs
@@ -41,8 +41,7 @@ namespace HFSM {
         private State anyState;
         private bool changedState;
         private bool _isUpdating;
-        private Queue<EventTransitionBase> _pendingInstantEvents;
-        private HashSet<EventTransitionBase> _pendingInstantSet;
+        private EventTransitionBase _pendingInstantEvent;
 
         /// <summary>
         /// Class constructor. Creates a <see cref="StateMachine"/> and initializes it. Throws
@@ -68,11 +67,6 @@ namespace HFSM {
             anyState.StateMachine = this;
             initialized = false;
             changedState = false;
-
-            _isUpdating = false;
-
-            _pendingInstantEvents = new Queue<EventTransitionBase>();
-            _pendingInstantSet = new HashSet<EventTransitionBase>();
 
             DefaultStateObject = stateObjects[0];
             foreach (StateObject stateObject in stateObjects) {
@@ -400,18 +394,6 @@ namespace HFSM {
         }
         #endregion
 
-        private void FlushPendingInstantEvents() {
-            if (_pendingInstantEvents.Count == 0) {
-                return;
-            }
-
-            while (_pendingInstantEvents.Count > 0) {
-                EventTransitionBase e = _pendingInstantEvents.Dequeue();
-                _pendingInstantSet.Remove(e);
-                ProcessInstantEvent(e);
-            }
-        }
-
         /// <summary>
         /// Tries to find an available <see cref="Transition"/> and then use it to change to a new
         /// <see cref="StateObject"/>.
@@ -543,8 +525,8 @@ namespace HFSM {
         /// </param>
         internal void ProcessInstantEvent(EventTransitionBase eventTransition) {
             if (_isUpdating) {
-                if (_pendingInstantSet.Add(eventTransition)) {
-                    _pendingInstantEvents.Enqueue(eventTransition);
+                if (_pendingInstantEvent == null) {
+                    _pendingInstantEvent = eventTransition;
                 }
                 return;
             }
@@ -555,8 +537,9 @@ namespace HFSM {
                 && eventTransition.AllConditionsMet()) {
 
                 ChangeState(eventTransition);
-                eventTransition.ConsumeEvent();
                 changedState = true;
+                
+                eventTransition.ConsumeEvent();
             }
         }
 
@@ -567,25 +550,21 @@ namespace HFSM {
         /// </summary>
         public sealed override void Update() {
             CheckInitialization();
-
             _isUpdating = true;
 
             changedState = TryChangeState();
             if (!changedState) {
                 OnUpdate();
-
-                // Allow events fired during OnUpdate() to preempt child update
-                _isUpdating = false;
-                FlushPendingInstantEvents();
-                _isUpdating = true;
-
-                if (!changedState && _pendingInstantEvents.Count == 0) {
-                    CurrentStateObject.UpdateInternal();
-                }
+                CurrentStateObject.UpdateInternal();
             }
 
             _isUpdating = false;
-            FlushPendingInstantEvents();
+
+            if (_pendingInstantEvent != null) {
+                var e = _pendingInstantEvent;
+                _pendingInstantEvent = null;
+                ProcessInstantEvent(e);
+            }
         }
 
         /// <summary>
@@ -593,8 +572,18 @@ namespace HFSM {
         /// hiearchical finite state machine pattern.
         /// </summary>
         internal sealed override void UpdateInternal() {
+            _isUpdating = true;
+
             OnUpdate();
             CurrentStateObject.UpdateInternal();
+
+            _isUpdating = false;
+
+            if (_pendingInstantEvent != null) {
+                var e = _pendingInstantEvent;
+                _pendingInstantEvent = null;
+                ProcessInstantEvent(e);
+            }
         }
 
         /// <summary>
@@ -604,14 +593,8 @@ namespace HFSM {
         /// </summary>
         public sealed override void FixedUpdate() {
             CheckInitialization();
-
-            _isUpdating = true;
-
             OnFixedUpdate();
             CurrentStateObject.FixedUpdate();
-
-            _isUpdating = false;
-            FlushPendingInstantEvents();
         }
 
         /// <summary>
@@ -621,16 +604,10 @@ namespace HFSM {
         /// </summary>
         public sealed override void LateUpdate() {
             CheckInitialization();
-
-            _isUpdating = true;
-
             if (!changedState) {
                 OnLateUpdate();
                 CurrentStateObject.LateUpdate();
             }
-
-            _isUpdating = false;
-            FlushPendingInstantEvents();
         }
 
         /// <summary>

--- a/Tests/Runtime/HFSMTest.cs
+++ b/Tests/Runtime/HFSMTest.cs
@@ -2351,4 +2351,115 @@ public class HFSMTest {
 
         Assert.AreEqual(expected, sb.ToString());
     }
+    [Test]
+    public void InstantEventTransitionOnInactiveSourceState()
+    {
+        State stateA = new StateA();
+        State stateB = new StateB();
+        State stateC = new StateC();
+        StateMachine zeroStateMachine = new StateMachineZero(stateA, stateB, stateC);
+        zeroStateMachine.DefaultStateObject = stateA;
+
+        Action transitionEventBC = null;
+        bool conditionBC = false;
+        transitionEventBC += stateB.AddEventTransition(stateC, true, () => { return conditionBC; });
+
+        Action transitionEventAC = null;
+        bool conditionAC = false;
+        transitionEventAC += stateA.AddEventTransition(stateC, true, () => { return conditionAC; });
+
+        zeroStateMachine.Init();
+        Assert.AreEqual(zeroStateMachine.GetType() + "." + stateA.GetType(),
+                        zeroStateMachine.GetCurrentStateName());
+
+        transitionEventBC.Invoke();
+        transitionEventAC.Invoke();
+        Assert.AreEqual(zeroStateMachine.GetType() + "." + stateA.GetType(),
+                        zeroStateMachine.GetCurrentStateName());
+
+        conditionBC = true;
+        transitionEventBC.Invoke();
+        transitionEventAC.Invoke();
+        Assert.AreEqual(zeroStateMachine.GetType() + "." + stateA.GetType(),
+                        zeroStateMachine.GetCurrentStateName());
+
+        conditionAC = true;
+        transitionEventBC.Invoke();
+        transitionEventAC.Invoke();
+        Assert.AreEqual(zeroStateMachine.GetType() + "." + stateC.GetType(),
+                        zeroStateMachine.GetCurrentStateName());
+    }
+
+    [Test]
+    public void InstantEventTransitionsEventIsConsumed()
+    {
+        State stateA = new StateA();
+        State stateB = new StateB();
+        StateMachine zeroStateMachine = new StateMachineZero(stateA, stateB);
+        zeroStateMachine.DefaultStateObject = stateA;
+
+        Action transitionEventAB = null;
+        bool conditionAB = false;
+        transitionEventAB += stateA.AddEventTransition(stateB, true, () => { return conditionAB; });
+
+        Action transitionEventBA = null;
+        bool conditionBA = false;
+        transitionEventBA += stateB.AddEventTransition(stateA, true, () => { return conditionBA; });
+
+        zeroStateMachine.Init();
+        Assert.AreEqual(zeroStateMachine.GetType() + "." + stateA.GetType(),
+                        zeroStateMachine.GetCurrentStateName());
+
+        conditionAB = true;
+        transitionEventAB.Invoke();
+        Assert.AreEqual(zeroStateMachine.GetType() + "." + stateB.GetType(),
+                        zeroStateMachine.GetCurrentStateName());
+
+        conditionBA = true;
+        transitionEventBA.Invoke();
+        Assert.AreEqual(zeroStateMachine.GetType() + "." + stateA.GetType(),
+                        zeroStateMachine.GetCurrentStateName());
+
+        zeroStateMachine.Update();
+        Assert.AreEqual(zeroStateMachine.GetType() + "." + stateA.GetType(),
+                        zeroStateMachine.GetCurrentStateName());
+    }
+
+    [Test]
+    public void PastEventTransitionsEventAreConsumed()
+    {
+        State stateA = new StateA();
+        State stateB = new StateB();
+        State stateC = new StateC();
+        StateMachine zeroStateMachine = new StateMachineZero(stateA, stateB, stateC);
+        zeroStateMachine.DefaultStateObject = stateA;
+
+        Action transitionEventAB = null;
+        bool conditionAB = false;
+        transitionEventAB += stateA.AddEventTransition(stateB, () => { return conditionAB; });
+
+        Action transitionEventBC = null;
+        bool conditionBC = false;
+        transitionEventBC += stateB.AddEventTransition(stateC, () => { return conditionBC; });
+
+        zeroStateMachine.Init();
+        Assert.AreEqual(zeroStateMachine.GetType() + "." + stateA.GetType(),
+                        zeroStateMachine.GetCurrentStateName());
+
+        conditionBC = true;
+        transitionEventBC.Invoke();
+        zeroStateMachine.Update();
+        Assert.AreEqual(zeroStateMachine.GetType() + "." + stateA.GetType(),
+                        zeroStateMachine.GetCurrentStateName());
+
+        conditionAB = true;
+        transitionEventAB.Invoke();
+        zeroStateMachine.Update();
+        Assert.AreEqual(zeroStateMachine.GetType() + "." + stateB.GetType(),
+                        zeroStateMachine.GetCurrentStateName());
+
+        zeroStateMachine.Update();
+        Assert.AreEqual(zeroStateMachine.GetType() + "." + stateB.GetType(),
+                        zeroStateMachine.GetCurrentStateName());
+    }
 }


### PR DESCRIPTION
Fixes a boolean precedence issue in StateMachine.ProcessInstantEvent that could bypass transition conditions when origin is active.

Fixes processInstantly event transitions never firing by ensuring eventListened is set before evaluating AllConditionsMet().