### PR TITLE
Fix: StateObject.Equals uses type comparison, preventing multiple instances of the same class

### DIFF
--- a/Runtime/StateObject.cs
+++ b/Runtime/StateObject.cs
@@ -32,7 +32,7 @@ namespace HFSM {
         /// <see langword="true"/> if the the <see cref="StateObject"/>s are of the same subclass, <see langword="false"/> otherwise.
         /// </returns>
         public bool Equals(StateObject otherStateObject) {
-            return this.GetType() == otherStateObject.GetType();
+            return ReferenceEquals(this, otherStateObject);
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

`StateObject.Equals` currently compares instances by type:
```csharp
public bool Equals(StateObject otherStateObject) {
    return this.GetType() == otherStateObject.GetType();
}
```

This means any two instances of the same class are considered identical. Breaking `ChangeState` and `FindLowestCommonStateMachine` when the hierarchy contains multiple instances of a reusable StateObject/StateMachine subclass.

E.g., a generic `AnimationState` class used to wrap different animations (my use-case atm):
```csharp
var idle = new AnimationState(idleAnim);
var walk = new AnimationState(walkAnim);
var airSM = new AnimationStateMachine(idle, walk);
var groundSM = new AnimationStateMachine(...);
var rootSM = new AnimationStateMachine(airSM, groundSM);
```

Here `airSM.Equals(groundSM)` and `idle.Equals(walk)` both return `true`, causing `ChangeState` to skip hierarchy updates and leaving the state machine in an incorrect state.

## Fix

Replace type comparison with reference equality:
```csharp
public bool Equals(StateObject otherStateObject) {
    return ReferenceEquals(this, otherStateObject);
}
```

Should still work w/ the previous "one-class-per-state" approach since distinct instances are still always distinct references. Additionally supports reusable generic state classes where multiple instances of the same type coexist in the hierarchy.